### PR TITLE
fix #12 properly walk Atrule to avoid orphan rules

### DIFF
--- a/index.js
+++ b/index.js
@@ -132,7 +132,9 @@ const walker = function (root, options = _default) {
     if (isFunction(rule.walk)) {
       walker(rule, options);
     }
+  });
 
+  root.walkAtRules(rule => {
     const remove = !rule.nodes || rule.nodes.length === 0;
     if (remove || checkAtrule(rule, options.atrule)) {
       rule.remove();

--- a/index.test.js
+++ b/index.test.js
@@ -90,7 +90,21 @@ it('returns unchanged css', () => {
   return run(styles, {}, styles);
 });
 
-it('removes atrule', () => {
+it('removes @supports atrule', () => {
+  return run(styles, {atrule: ['@supports']}).then(({css}) => {
+    expect(css).toMatch('@font-face');
+    expect(css).toMatch('font-family: \'Glyphicons Halflings\'');
+    expect(css).toMatch('html');
+    expect(css).toMatch('.my.awesome.selector');
+    expect(css).toMatch('main h1 > p');
+    expect(css).toMatch('.test');
+    expect(css).toMatch('only print');
+    expect(css).not.toMatch('@supports');
+    expect(css).not.toMatch('.testa');
+  });
+});
+
+it('removes @font-face atrule', () => {
   return run(styles, {atrule: '@font-face'}).then(({css}) => {
     expect(css).not.toMatch('@font-face');
     expect(css).not.toMatch('font-family: \'Glyphicons Halflings\'');


### PR DESCRIPTION
There is an issue in discarding `@supports` rules (and possibly other types of Atrules) due to the recursive walker implemented. Since `root.walkAtRules()` traverses all descendant nodes (not just direct descendants), there are cases in which the container is removed before all children have been processed by `.walkDecls()` and `.walkRules()`.

Invoking `walkAtRules()` twice, first to allow discovery of rules and declarations within @ blocks and finally to remove empty or target at rules fixes it.

Added one test to cover this specific case.