### PR TITLE
Throw postCSS parsing error instead of printing it

### DIFF
--- a/index.js
+++ b/index.js
@@ -90,7 +90,7 @@ const getCssMapping = css => {
     if (fs.existsSync(css)) {
       ast = postcss.parse(fs.readFileSync(css, 'utf8'), {from: undefined});
     } else {
-      console.error(error.message);
+      throw error;
     }
   }
 


### PR DESCRIPTION
Hi, following https://github.com/Tom-Bonnike/netlify-plugin-inline-critical-css/issues/7, I’m wondering why the plugin prints the postCSS parsing error instead of throwing and stopping its execution?
If `ast` is undefined, line 98 will fail, leading to a more cryptic error than the nice post CSS errors. Throwing early seems like a better developer experience.